### PR TITLE
Removed \color{title} from rename of Bibliography to References

### DIFF
--- a/dissertation.cls
+++ b/dissertation.cls
@@ -460,7 +460,7 @@
 }
 
 %% Create an unnumbered reference section.
-\addto\captionsenglish{\renewcommand*\bibname{\color{title}References}}
+\addto\captionsenglish{\renewcommand*\bibname{References}}
 \newcommand*\references[1]{%
     \bibliographystyle{dissertation}%
     \bibliography{#1}%


### PR DESCRIPTION
I found the Index pane in PDF readers showed "titleReferences" instead of "References". This is due to the fact that the \color control word is not available in that scope. The section "References" shows up blue anyways since that is the titleformat, so it can be safely removed.
