### PR TITLE
Added \setheader commands for unnumbered chapters

### DIFF
--- a/acks/acks.tex
+++ b/acks/acks.tex
@@ -1,5 +1,6 @@
 \chapter*{Acknowledgements}
 \addcontentsline{toc}{chapter}{Acknowledgements}
+\setheader{Acknowledgements}
 \label{acknowledgements}
 
 This is an optional chapter containing acknowledgements.

--- a/epilogue/epilogue.tex
+++ b/epilogue/epilogue.tex
@@ -1,5 +1,6 @@
 \chapter*{Epilogue}
 \addcontentsline{toc}{chapter}{Epilogue}
+\setheader{Epilogue}
 \label{epilogue}
 
 This is an optional epilogue.


### PR DESCRIPTION
I found 2 unnumbered chapters had no \setheader command specified, hence, when these chapters grow larger than 1 page, the header shows the title of the previous chapter that specified a header.
