### PR TITLE
Solved a bug found in package titlesec version 2.10.1

### DIFF
--- a/dissertation.cls
+++ b/dissertation.cls
@@ -47,6 +47,19 @@
 \RequirePackage[sectionbib,numbers,sort&compress]{natbib}
 \RequirePackage{tikz}
 \RequirePackage[noindentafter]{titlesec}
+\@ifpackagelater{titlesec}{2016/03/21}{%
+	% Package titlesec is on version 2.10.2 or higher, nothing to do %
+}{%
+	% Check if package titlesec is on version 2.10.1 %
+	\@ifpackagelater{titlesec}{2016/03/15}{%
+		% Package titlesec on version 2.10.1, patch accordingly %
+		\RequirePackage{etoolbox}%
+		\patchcmd{\ttlh@hang}{\parindent\z@}{\parindent\z@\leavevmode}{}{}%
+		\patchcmd{\ttlh@hang}{\noindent}{}{}{}%
+	}{%
+		% Package titlsec is on version 2.10.0 or lower, nothing to do %
+	}%
+}
 \RequirePackage{titletoc}
 \RequirePackage[nottoc]{tocbibind}
 \RequirePackage{xcolor}


### PR DESCRIPTION
In package titlesec version 2.10.1 (released on 15/03/2016), there was a bug that removed the section and subsection numbers in frond of section and subsection titles. Although already solved in titlesec version 2.10.2 (released on 21/03/2016), the previous version of titlesec (and thus the bug) lingers on in quite some repositories. It took me a couple of months (combined with acceptation and hope it would fix itself before my dissertation was due, though it was quite frustrating to revise having no section numbers) to find out it was this exact package and there was an updated version to fix it that I had to install by hand. Hence, I wrote a small patch for the dissertation-layout that checks the version of titlesec in use, and apply the patch at runtime if 2.10.1 is indeed installed.

For the full story of the bug, have a look at the following links:
https://bugs.launchpad.net/ubuntu/+source/texlive-extra/+bug/1574052
http://tex.stackexchange.com/questions/299969/titlesec-loss-of-section-numbering-with-the-new-update-2016-03-15/300259#300259
